### PR TITLE
Added composer.json description and newer symfony proccess versions can be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "mariusbuescher/node-composer",
     "type": "composer-plugin",
+    "description": "Installs composer nodejs or/and npm in vendor/",
     "license": "MIT",
     "keywords": [
         "node.js",
@@ -25,7 +26,7 @@
         "php": ">=5.5.9",
         "composer/composer": "^1.4",
         "composer-plugin-api": "^1.1",
-        "symfony/process": "^2.7 || ^3.0"
+        "symfony/process": "^2.7 || >=3.0"
     },
     "extra": {
         "class": "MariusBuescher\\NodeComposer\\NodeComposerPlugin"


### PR DESCRIPTION
`description` field in composer.json if type is not library is required. So I added.

Also, from now it's possible to use this little composer-plugin in projects with never symfony process versions.