### PR TITLE
Adds amd64 and i586 architectures to ArchitectureMap

### DIFF
--- a/src/ArchitectureMap.php
+++ b/src/ArchitectureMap.php
@@ -8,7 +8,9 @@ class ArchitectureMap
      * @var array
      */
     private static $map = array(
-        'x86_64' => 'x64'
+        'x86_64' => 'x64',
+        'amd64' => 'x64',
+        'i586' => 'x86',
     );
 
     /**


### PR DESCRIPTION
After running CI tests I found out that amd64 and i586 values are needed to be added into ArchitectureMap file, because some GitHub machines returns these values instead of x64 or x86. So, here is the fix.