### PR TITLE
Lowercase architecture mapping

### DIFF
--- a/src/ArchitectureMap.php
+++ b/src/ArchitectureMap.php
@@ -17,6 +17,7 @@ class ArchitectureMap
      */
     public static function getNodeArchitecture($phpArchitecture)
     {
-        return isset(static::$map[$phpArchitecture]) ? static::$map[$phpArchitecture] : $phpArchitecture;
+        $lowercaseArchitecture = strtolower($phpArchitecture);
+        return isset(static::$map[$lowercaseArchitecture]) ? static::$map[$lowercaseArchitecture] : $phpArchitecture;
     }
 }


### PR DESCRIPTION
It seems that some GitHub machines returns architecture in uppercase, but on my localhost I see only lowercase variants, so change makes sure that mapping allways works as architecture value is in lowercase. 