### PR TITLE
Bump minimal PHP version to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.1",
         "composer/composer": "^1.4",
         "composer-plugin-api": "^1.1",
         "symfony/process": "^2.7 || >=3.0"


### PR DESCRIPTION
It seems that ZipArchiver on Windows with PHP 7.0 can't extract correctly node archives, so I bumped minimal required PHP version in composer.json to 7.1