### PR TITLE
Adds possibility to define config not only in project extras but also in dependencies

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -40,12 +40,43 @@ class Config
         $self->nodeDownloadUrl = isset($conf['node-download-url']) ? $conf['node-download-url'] : null;
         $self->yarnVersion = isset($conf['yarn-version']) ? $conf['yarn-version'] : null;
 
-        if ($self->nodeVersion === null) {
-            throw new NodeComposerConfigException('You must specify a node-version');
+        return $self;
+    }
+
+    /**
+     * Selects best config from configs list
+     *
+     * @param Config[] $configs
+     * @return Config
+     */
+    public static function selectBest(array $configs) {
+        $maxNodeVersion = null;
+        $maxYarnVersion = null;
+        $nodeDownloadUrl = null;
+        foreach ($configs as $config) {
+            if ($maxNodeVersion === null) {
+                $maxNodeVersion = $config->nodeVersion;
+            } elseif (version_compare($config->nodeVersion, $maxNodeVersion, '>')) {
+                $maxNodeVersion = $config->nodeVersion;
+            }
+            if ($maxYarnVersion === null) {
+                $maxYarnVersion = $config->yarnVersion;
+            } elseif (version_compare($config->yarnVersion, $maxYarnVersion, '>')) {
+                $maxYarnVersion = $config->yarnVersion;
+            }
+            if ($nodeDownloadUrl === null) {
+                $nodeDownloadUrl = $config->nodeDownloadUrl;
+            } elseif ($nodeDownloadUrl !== $config->nodeDownloadUrl) {
+                throw new NodeComposerConfigException('Defined different nodejs download urls are unsupported right now');
+            }
         }
 
+        $ret = new self();
+        $ret->nodeDownloadUrl = $nodeDownloadUrl;
+        $ret->yarnVersion = $maxYarnVersion;
+        $ret->nodeVersion = $maxNodeVersion;
 
-        return $self;
+        return $ret;
     }
 
     /**


### PR DESCRIPTION
This will let to define config not only in project level but also in also in dependencies. 

If there are multiple dependencies, with different node or yarn versions, max versions will be selected (yeah I, know, that would be awesome to have multiple nodejs and/or yarn versions installed, but I think this requires some huge changes... so at least something for now...)

Project level config definitions takes priority. That means if these are found, all configs in dependencies will be ignored.

Accepting this change let others to create libraries that depends on node-composer that could be used in projects. For example, a package that automatically bumps owen version everytime new nodejs is released (similar thing that I tried to achieve with #2 pull request). Or some package that automatically tries to deal with front-end npm assets management.

*Note:* #10 must be merged first to make sure that all platform tests succeeds.