### PR TITLE
If specific packages are found in project installation, gets versions from yarn and nodejs from these packages config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,10 @@
         "symfony/process": "^2.7 || >=3.0",
         "symfony/filesystem": ">=2.7"
     },
+    "suggest": {
+        "imponeer/composer-yarn-installer": "Lets use composer constraints for updating yarn package version",
+        "imponeer/composer-nodejs-installer": "Lets use composer constraints for updating nodejs package version"
+    },
     "extra": {
         "class": "MariusBuescher\\NodeComposer\\NodeComposerPlugin"
     }

--- a/src/NodeComposerPlugin.php
+++ b/src/NodeComposerPlugin.php
@@ -10,8 +10,8 @@ use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Composer\Util\RemoteFilesystem;
-use MariusBuescher\NodeComposer\Exception\VersionVerificationException;
 use MariusBuescher\NodeComposer\Exception\NodeComposerConfigException;
+use MariusBuescher\NodeComposer\Exception\VersionVerificationException;
 use MariusBuescher\NodeComposer\Installer\NodeInstaller;
 use MariusBuescher\NodeComposer\Installer\YarnInstaller;
 
@@ -44,13 +44,13 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
             $packageConfig,
             'node-version',
             'imponeer/composer-nodejs-installer',
-            'nodejs'
+            'nodejs/node'
         );
         $this->updateConfigFromPackageProvidesConfig(
             $packageConfig,
             'yarn-version',
             'imponeer/composer-yarn-installer',
-            'yarn'
+            'yarnpkg/yarn'
         );
 
         if (empty($packageConfig)) {

--- a/src/NodeComposerPlugin.php
+++ b/src/NodeComposerPlugin.php
@@ -43,13 +43,13 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
         $this->updateConfigFromPackageProvidesConfig(
             $packageConfig,
             'node-version',
-            'imponeer/composer-nodejs-installer',
+            $packageConfig['package-for-node-version'] ?? 'imponeer/composer-nodejs-installer',
             'nodejs/node'
         );
         $this->updateConfigFromPackageProvidesConfig(
             $packageConfig,
             'yarn-version',
-            'imponeer/composer-yarn-installer',
+            $packageConfig['package-for-yarn-version'] ?? 'imponeer/composer-yarn-installer',
             'yarnpkg/yarn'
         );
 


### PR DESCRIPTION
Similar to #14 but instead of having multiple version conflicts, correct nodejs and yarn versions are detected from imponeer/composer-nodejs-installer and imponeer/composer-yarn-installer package data. So, if any of these packages are installed in project, config values will be overwritten from these packages data.

F.e., if project has such composer.json:
```yaml
{
  "name": "dummy/dummy",
  "description": "Dummy project to test if configuration works",
  "type": "project",
  "require": {
    "mariusbuescher/node-composer": "@dev",
    "imponeer/composer-nodejs-installer": "1.0.0"
  }
}
```
Node 1.0.0 will be installed

or if project has such composer.json:
```yaml
{
  "name": "dummy/dummy",
  "description": "Dummy project to test if configuration works",
  "type": "project",
  "require": {
    "mariusbuescher/node-composer": "@dev",
    "imponeer/composer-nodejs-installer": "1.0.0",
    "imponeer/composer-yarn-installer": "1.0.0",
  }
}
```
Node 1.0.0 and yarn 1.0.0 will be installed

or  if project has such composer.json:
```yaml
{
  "name": "dummy/dummy",
  "description": "Dummy project to test if configuration works",
  "type": "project",
  "require": {
    "mariusbuescher/node-composer": "@dev",
    "imponeer/composer-yarn-installer": "1.0.0",
  }
}
```
Latest nodejs and yarn 1.0.0 version will be installed 

or if such composer.json:
```yaml
{
  "name": "dummy/dummy",
  "description": "Dummy project to test if configuration works",
  "type": "project",
  "require": {
    "mariusbuescher/node-composer": "@dev",
    "imponeer/composer-yarn-installer": "1.0.0",
  },
  "extra": {
        "mariusbuescher": {
            "node-composer": {
                "node-version": "6.11.0"            
            }
        }
    }
}
```
Yarn 1.0.0 and node 6.11.0 will be installed

However if both ways are defined, data from packages (not extras will take a priority). So, that's means that such composer.json config:
```yaml
{
  "name": "dummy/dummy",
  "description": "Dummy project to test if configuration works",
  "type": "project",
  "require": {
    "mariusbuescher/node-composer": "@dev",
    "imponeer/composer-yarn-installer": "1.0.0",
  },
  "extra": {
        "mariusbuescher": {
            "node-composer": {
                "yarn-version": "0.11.0" 
                "node-version": "6.11.0" 
            }
        }
    }
}
```
This would install yarn 1.0.0 and node 6.11.0

Of cource it will be possible to use composer version constraints for such new functionality. So, it would be easier to update package nodejs versions.

Yeah, I know this is a bit hardcoded that is not very good practice but I think this would be maybe a bit better way to solve this problem than #14 and this doesn't required to solve a big problem how to handle multiple installed nodejs and yarn versions. What do you think?