### PR TITLE
Fix Process.php expected type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PHP projects mostly are Web-Applications. Many Web-Applications also need a fron
 modern Web-Development there often a whole build-chain connected to the frontend, so you can compile e.g. your scss, build
 your JavaScript with webpack and optimize your images.
 
-This plugin provides a way to automatically download and installthe right version of node.js, npm and yarn. The binaries
+This plugin provides a way to automatically download and install the right version of node.js, npm and yarn. The binaries
 are linked to the bin-directory specified in your composer.json.
 
 After that your can use node, npm and yarn in your composer-scripts.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.1",
         "composer/composer": "^1.4 || ^2.0",
         "composer-plugin-api": "^1.0 || ^2.0",
-        "symfony/process": "^2.7 || >=3.0",
+        "symfony/process": "~4 || ~5 || ~6",
         "symfony/filesystem": ">=2.7"
     },
     "extra": {

--- a/src/Installer/NodeInstaller.php
+++ b/src/Installer/NodeInstaller.php
@@ -79,9 +79,10 @@ class NodeInstaller implements InstallerInterface
      */
     public function isInstalled()
     {
-        $nodeExecutable = $this->context->getBinDir() . DIRECTORY_SEPARATOR . 'node';
 
-        $process = new Process("$nodeExecutable --version");
+        $process = new Process(["node --version"], $this->context->getBinDir());
+        $process->setIdleTimeout(null);
+        $process->setTimeout(null);
         $process->run();
 
         if ($process->isSuccessful()) {


### PR DESCRIPTION
`symfony/process` in 3.x and below expects a string, but in 4.x and up expects an array. This will fix anyone using 4 and up, and should be split out into a different base version.

This fix should be tagged in a 2.x version

fixes #16 